### PR TITLE
Fixing Traditional Chinese (zh_tw.json)

### DIFF
--- a/src/main/resources/assets/waterplayer/lang/zh_tw.json
+++ b/src/main/resources/assets/waterplayer/lang/zh_tw.json
@@ -67,7 +67,7 @@
   "waterplayer.load.add": "您的請求已發送",
   "waterplayer.load.add.blank": "空白請求！",
 
-  "waterplayer.format.time": "{track.time.position} / {track.time.duration}",
+  "waterplayer.format.time": "{waterplayer.track.time.position} / {waterplayer.track.time.duration}",
   "waterplayer.format.live": "（直播）",
 
   "waterplayer.config": "組態",


### PR DESCRIPTION
Fix time showing null in game overlay
Исправить отображение времени как "null" в игровом оверлее
![image](https://github.com/user-attachments/assets/a67ea1a3-124d-4ab9-a62f-3fbdf40b64f5)
